### PR TITLE
Fix build issues

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -67,11 +67,11 @@ impl CargoTools {
         };
 
         // Check for default toolchain from environment variable
-        if let Ok(toolchain) = std::env::var("CARGO_MCP_DEFAULT_TOOLCHAIN")
-            && !toolchain.is_empty()
-        {
-            log::info!("Setting default toolchain from CARGO_MCP_DEFAULT_TOOLCHAIN: {toolchain}");
-            tools.set_default_toolchain(Some(toolchain), None)?;
+        if let Ok(toolchain) = std::env::var("CARGO_MCP_DEFAULT_TOOLCHAIN") {
+            if !toolchain.is_empty() {
+                log::info!("Setting default toolchain from CARGO_MCP_DEFAULT_TOOLCHAIN: {toolchain}");
+                tools.set_default_toolchain(Some(toolchain), None)?;
+            }
         }
 
         Ok(tools)

--- a/src/tools/cargo_add.rs
+++ b/src/tools/cargo_add.rs
@@ -131,11 +131,12 @@ impl Tool<CargoTools> for CargoAdd {
 
         let features_str;
 
-        if let Some(ref features) = self.features
-            && !features.is_empty() {
+        if let Some(ref features) = self.features {
+            if !features.is_empty() {
                 features_str = features.join(",");
                 args.extend_from_slice(&["--features", &features_str]);
             }
+        }
 
         // Add the dependencies
         for dep in &self.dependencies {

--- a/src/tools/cargo_run.rs
+++ b/src/tools/cargo_run.rs
@@ -150,12 +150,12 @@ impl Tool<CargoTools> for CargoRun {
         }
 
         // Add separator and binary arguments if provided
-        if let Some(ref binary_args) = self.args
-            && !binary_args.is_empty()
-        {
-            args.push("--");
-            for arg in binary_args {
-                args.push(arg);
+        if let Some(ref binary_args) = self.args {
+            if !binary_args.is_empty() {
+                args.push("--");
+                for arg in binary_args {
+                    args.push(arg);
+                }
             }
         }
 


### PR DESCRIPTION
It seems like it's not possible to compile the project using Rust 1.87.0 because it fails with:

```
   Compiling cargo-mcp v0.2.0
error[E0658]: `let` expressions in this position are unstable
  --> /home/workspace/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-mcp-0.2.0/src/state.rs:70:12
   |
70 |         if let Ok(toolchain) = std::env::var("CARGO_MCP_DEFAULT_TOOLCHAIN")   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   |
   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
error[E0658]: `let` expressions in this position are unstable
   --> /home/workspace/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-mcp-0.2.0/src/tools/cargo_add.rs:134:12
    |
134 |         if let Some(ref features) = self.features
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
error[E0658]: `let` expressions in this position are unstable
   --> /home/workspace/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-mcp-0.2.0/src/tools/cargo_run.rs:153:12
    |
153 |         if let Some(ref binary_args) = self.args
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
For more information about this error, try `rustc --explain E0658`.
error: could not compile `cargo-mcp` (bin "cargo-mcp") due to 3 previous errors
error: failed to compile `cargo-mcp v0.2.0`, intermediate artifacts can be found at `/tmp/cargo-installfKKETW`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```

This PR (note: Claude Opus 4.1!) solves the issue.